### PR TITLE
Remove duplicate Vol.N: Vol.N:

### DIFF
--- a/_includes/aside.html
+++ b/_includes/aside.html
@@ -8,8 +8,8 @@
 
     <div class="cover-text">
       <div class="heading">
-        {% if page.volume %}
-          <a href="{{ post.url }}">Vol.{{ page.volume }}: {{ page.title }}</a>
+        {% if page.title %}
+          <a href="{{ post.url }}">{{ page.title }}</a>
         {% else %}
           <a href="{{ site.url }}">{{ site.title }}</a>
         {% endif %}

--- a/_posts/2016-11-12-vol1.md
+++ b/_posts/2016-11-12-vol1.md
@@ -15,7 +15,6 @@ audio_file_path: /audio/2016-11-12.mp3
 audio_file_size: 84605096
 duration: "58:45"
 author: timakin
-volume: 1
 ---
 
 ## おことわり

--- a/_posts/2016-11-22-vol2.md
+++ b/_posts/2016-11-22-vol2.md
@@ -15,7 +15,6 @@ audio_file_path: /audio/2016-11-22.mp3
 audio_file_size: 27526710
 duration: "57:20"
 author: timakinll
-volume: 2
 ---
 
 ## おことわり
@@ -35,4 +34,3 @@ volume: 2
 - [Who uses Redux?](https://github.com/reactjs/redux/issues/310)
 - [next.js](https://github.com/zeit/next.js)
 - [ErgoDoxを2枚買ってキースイッチを交換した](http://k0kubun.hatenablog.com/entry/ergodox)
-

--- a/archive.md
+++ b/archive.md
@@ -18,13 +18,8 @@ active: archive
   {% for post in posts %}
     {% if post.tags contains t %}
       <li>
-        {% if post.lastmod %}
-          <a href="{{ post.url }}">Vol.{{ post.volume }}: {{ post.title }}</a>
-          <span class="date">{{ post.lastmod | date: "%d-%m-%Y"  }}</span>
-        {% else %}
-          <a href="{{ post.url }}">{{ post.title }}</a>
-          <span class="date">{{ post.date | date: "%d-%m-%Y"  }}</span>
-        {% endif %}
+        <a href="{{ post.url }}">{{ post.title }}</a>
+        <span class="date">{{ post.date | date: "%d-%m-%Y"  }}</span>
       </li>
     {% endif %}
   {% endfor %}

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ summary: "A podcast by timakin and k0kubun, talking about technology, business n
 
 {% for post in site.posts limit: 5 %}
   <article class="index-page">
-    <h2><a href="{{ post.url }}">Vol.{{ post.volume }}: {{ post.title }}</a></h2>
+    <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
     <p>{{ post.description }}</p>
   </article>
 {% endfor %}


### PR DESCRIPTION
`Vol.N:` をタイトルに含めるようになったので (yatteiki.fmでもそう書いていて多分そのほうが楽)、HTMLテンプレート側で `Vol.N:` を書く必要が無くなったぞ、ということで消してみました。

## Before

![image](https://cloud.githubusercontent.com/assets/111689/20535022/ae6d6f3c-b126-11e6-864d-a5f7754af762.png)

![image](https://cloud.githubusercontent.com/assets/111689/20535420/0769a74e-b128-11e6-986d-0fc2abb916f7.png)

## After

![image](https://cloud.githubusercontent.com/assets/111689/20535065/d6f05032-b126-11e6-9730-52e0c28b2088.png)

![image](https://cloud.githubusercontent.com/assets/111689/20535435/104c6a86-b128-11e6-9d2e-43158adc3dee.png)
